### PR TITLE
ユーザにステータスを付与

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,6 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:user_type])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:user_type, :description])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,6 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:status])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:user_type])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,5 +5,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:user_type, :description])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:user_type, :description])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,2 @@
 class ApplicationController < ActionController::Base
-  before_action :configure_permitted_parameters, if: :devise_controller?
-  protect_form_forgery with: :exception
-
-  def configure_permitted_parameters
-    devise_parameter_sanitizer.for(:sign_up) {|u| u.permit(:email, :password, :password_confirmation, :type)}
-  end
-
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+  protect_form_forgery with: :exception
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.for(:sign_up) {|u| u.permit(:email, :password, :password_confirmation, :type)}
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:user_type, :description])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:user_type, :description])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:user_type, :description, :image])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:user_type, :description, :image])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:status])
+  end
 end

--- a/app/models/lab_user.rb
+++ b/app/models/lab_user.rb
@@ -2,3 +2,7 @@ class LabUser < ApplicationRecord
   belongs_to :user
   belongs_to :lab
 end
+
+class LabUser < ActiveRecord::Base
+  enum type: {student: 0, professor: 1, company: 2}
+end

--- a/app/models/lab_user.rb
+++ b/app/models/lab_user.rb
@@ -2,7 +2,3 @@ class LabUser < ApplicationRecord
   belongs_to :user
   belongs_to :lab
 end
-
-class LabUser < ActiveRecord::Base
-  enum type: {student: 0, professor: 1, company: 2}
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,5 +13,11 @@ class User < ApplicationRecord
         return true
     end
     return false
+  end
+  
+  enum type: {student: 0, professor: 1, company: 2}
 end
-end
+
+# class User < ActiveRecord::Base
+#   enum type: {student: 0, professor: 1, company: 2}
+# end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,9 @@ class User < ApplicationRecord
   has_many :lab_users
   has_many :labs, through: :lab_users
 
+  enum status: {student: 0, professor: 1, company: 2}
+  validates :status, presence: true
+
   # user が研究室に所属しているか
   def has_labs?
     if self.labs
@@ -14,10 +17,5 @@ class User < ApplicationRecord
     end
     return false
   end
-  
-  enum type: {student: 0, professor: 1, company: 2}
-end
 
-# class User < ActiveRecord::Base
-#   enum type: {student: 0, professor: 1, company: 2}
-# end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   # set status of User
   enum user_type: {student: 0, professor: 1, company: 2}
   validates :user_type, presence: true
+  validates :description, presence: true, length: {minimum: 5, maximum: 256}
 
   # user が研究室に所属しているか
   def has_labs?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   has_many :lab_users
   has_many :labs, through: :lab_users
 
+  # set status of User
   enum status: {student: 0, professor: 1, company: 2}
   validates :status, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,8 +8,8 @@ class User < ApplicationRecord
   has_many :labs, through: :lab_users
 
   # set status of User
-  enum status: {student: 0, professor: 1, company: 2}
-  validates :status, presence: true
+  enum user_type: {student: 0, professor: 1, company: 2}
+  validates :user_type, presence: true
 
   # user が研究室に所属しているか
   def has_labs?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,9 @@ class User < ApplicationRecord
   has_many :lab_users
   has_many :labs, through: :lab_users
 
+  # for ActiveStorage
+  has_one_attached :image
+
   # set status of User
   enum user_type: {student: 0, professor: 1, company: 2}
   validates :user_type, presence: true

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -31,6 +31,16 @@
     <%= f.password_field :current_password, autocomplete: "current-password" %>
   </div>
 
+  <div class="field">
+    <%= f.label :user_type %><br />
+    <%= f.select :user_type, User.user_types.keys%>
+  </div>
+
+  <div class="field">
+    <%= f.label :description  %><br />
+    <%= f.text_field :description, autocomplete: "description" %>
+  </div>
+
   <div class="actions">
     <%= f.submit "Update" %>
   </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -31,6 +31,7 @@
     <%= f.password_field :current_password, autocomplete: "current-password" %>
   </div>
 
+<!-- email, password以外の要素 -->
   <div class="field">
     <%= f.label :user_type %><br />
     <%= f.select :user_type, User.user_types.keys%>
@@ -39,6 +40,11 @@
   <div class="field">
     <%= f.label :description  %><br />
     <%= f.text_field :description, autocomplete: "description" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :image %>
+    <%= f.file_field :image %>
   </div>
 
   <div class="actions">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -22,8 +22,8 @@
   </div>
 
   <div class="field">
-    <%= f.label :status %><br />
-    <%= f.select :status, User.statuses.keys %>
+    <%= f.label :user_type %><br />
+    <%= f.select :user_type, User.user_types.keys %>
   </div>
 
   <div class="actions">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -21,6 +21,7 @@
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
+<!-- email, password以外の要素 -->
   <div class="field">
     <%= f.label :user_type %><br />
     <%= f.select :user_type, User.user_types.keys %>
@@ -29,6 +30,11 @@
   <div class="field">
     <%= f.label :description %><br />
     <%= f.text_field :description%>
+  </div>
+
+  <div class="field">
+    <%= f.label :image %>
+    <%= f.file_field :image %>
   </div>
 
   <div class="actions">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -22,8 +22,8 @@
   </div>
 
   <div class="field">
-    <%= f.label :type %><br />
-    <%= f.select :type, User.types.keys %>
+    <%= f.label :status %><br />
+    <%= f.select :status, User.statuses.keys %>
   </div>
 
   <div class="actions">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -21,6 +21,11 @@
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
+  <div class="field">
+    <%= f.label :type %><br />
+    <%= f.text_field :type %>
+  </div>
+
   <div class="actions">
     <%= f.submit "Sign up" %>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -23,7 +23,7 @@
 
   <div class="field">
     <%= f.label :type %><br />
-    <%= f.text_field :type %>
+    <%= f.select :type, User.types.keys %>
   </div>
 
   <div class="actions">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -26,6 +26,11 @@
     <%= f.select :user_type, User.user_types.keys %>
   </div>
 
+  <div class="field">
+    <%= f.label :description %><br />
+    <%= f.text_field :description%>
+  </div>
+
   <div class="actions">
     <%= f.submit "Sign up" %>
   </div>

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -1,6 +1,15 @@
 <h1>こんにちは、<%= current_user.id %>さん</h1>
 <p>ユーザー用ページです。</p>
 
+<!-- Show user icon -->
+<% if current_user.image.attached? %>
+  <p>
+    <strong>Your Icon:</strong>
+    <%= image_tag current_user.image, :size => "100x100" %>
+  </p>
+<% end %>
+
+
 <% if current_user.has_labs? %>
     <h2>所属研究室一覧</h2>
     <% current_user.labs.each do |lab| %>

--- a/db/migrate/20181004173505_rename_type_column_to_users.rb
+++ b/db/migrate/20181004173505_rename_type_column_to_users.rb
@@ -1,0 +1,5 @@
+class RenameTypeColumnToUsers < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :users, :type, :status
+  end
+end

--- a/db/migrate/20181004173505_rename_type_column_to_users.rb
+++ b/db/migrate/20181004173505_rename_type_column_to_users.rb
@@ -1,5 +1,5 @@
 class RenameTypeColumnToUsers < ActiveRecord::Migration[5.2]
   def change
-    rename_column :users, :type, :status
+    rename_column :users, :type, :user_type
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_23_053028) do
+ActiveRecord::Schema.define(version: 2018_10_04_173505) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -98,7 +98,7 @@ ActiveRecord::Schema.define(version: 2018_09_23_053028) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "description"
-    t.integer "type"
+    t.integer "status"
     t.integer "image"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -98,7 +98,7 @@ ActiveRecord::Schema.define(version: 2018_10_04_173505) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "description"
-    t.integer "status"
+    t.integer "user_type"
     t.integer "image"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_04_173505) do
+ActiveRecord::Schema.define(version: 2018_10_06_033253) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -99,7 +99,6 @@ ActiveRecord::Schema.define(version: 2018_10_04_173505) do
     t.datetime "updated_at", null: false
     t.string "description"
     t.integer "user_type"
-    t.integer "image"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
@hiracky16 
ユーザのステータス設定と、サインアップ時にステータスを登録できるようにしました。
ご確認のほどお願いいたします。
【確認点】
- [ ] サインアップ
- [ ] ステータス(リスト式)を選択
- [ ] DBに登録されているか確認

※ユーザのステータスを表すカラム名はtypeでしたが、typeというカラム名を使うとエラーが出た（https://qiita.com/ryonext/items/1a813639ab2a2a00058e ）ので、マイグレーションファイルでカラム名をstatusに変更しました。

【参考】
http://totech.hateblo.jp/entry/2015/12/19/144943
https://easyramble.com/add-field-devise-signup-form.html
https://re-engines.com/2017/06/30/707/
