### PR TITLE
#18 main_image, sub_imageをRemoveしました

### DIFF
--- a/db/migrate/20181028054111_remove_main_image_from_labs.rb
+++ b/db/migrate/20181028054111_remove_main_image_from_labs.rb
@@ -1,0 +1,5 @@
+class RemoveMainImageFromLabs < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :labs, :main_image, :text
+  end
+end

--- a/db/migrate/20181028054430_remove_sub_image_from_labs.rb
+++ b/db/migrate/20181028054430_remove_sub_image_from_labs.rb
@@ -1,0 +1,5 @@
+class RemoveSubImageFromLabs < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :labs, :sub_image, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_24_150355) do
+ActiveRecord::Schema.define(version: 2018_10_28_054430) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -78,8 +78,6 @@ ActiveRecord::Schema.define(version: 2018_10_24_150355) do
     t.string "name"
     t.string "majar"
     t.string "about_us"
-    t.text "main_image"
-    t.text "sub_image"
     t.string "purpose"
     t.string "message"
     t.string "facility"


### PR DESCRIPTION
railsコマンドにて
`docker-compose run web rails generate migration RemoveMain_imageFromLabs
 main_image:text`
`docker-compose run web rails generate migration RemoveSub_imageFromLabs
 sub_image:text`
を実行し、
（`docker-compose run web rake db:migrate`で確認？ちょっとよくわからなかったけどとりあえず実行）
そして、db:create, migrate後、sqlにてテーブルが削除されているのを確認しました。
また、schema.rb内の記述も削除されているのを確認しました。
以上、追加、変更された3つのファイルをupしています。
確認お願いします。