### PR TITLE
研究室検索機能の作成（学生用） #20

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'dotenv-rails'
 # gem 'elasticsearch-rails', git: 'git://github.com/elasticsearch/elasticsearch-rails.git'
 gem 'elasticsearch-model', git: 'https://github.com/elasticsearch/elasticsearch-rails.git', branch: "6.x"
 gem 'elasticsearch-rails', git: 'https://github.com/elasticsearch/elasticsearch-rails.git', branch: "6.x"
+gem 'elasticsearch-dsl', git: 'git://github.com/elasticsearch/elasticsearch-ruby.git', branch: "6.x"
 
 
 # Reduces boot times through caching; required in config/boot.rb

--- a/Gemfile
+++ b/Gemfile
@@ -40,8 +40,8 @@ gem 'dotenv-rails'
 # elastic-search
 # gem 'elasticsearch-model', git: 'git://github.com/elasticsearch/elasticsearch-rails.git'
 # gem 'elasticsearch-rails', git: 'git://github.com/elasticsearch/elasticsearch-rails.git'
-gem 'elasticsearch-model', git: 'https://github.com/elasticsearch/elasticsearch-rails.git', branch: "5.x"
-gem 'elasticsearch-rails', git: 'https://github.com/elasticsearch/elasticsearch-rails.git', branch: "5.x"
+gem 'elasticsearch-model', git: 'https://github.com/elasticsearch/elasticsearch-rails.git', branch: "6.x"
+gem 'elasticsearch-rails', git: 'https://github.com/elasticsearch/elasticsearch-rails.git', branch: "6.x"
 
 
 # Reduces boot times through caching; required in config/boot.rb

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,13 @@ gem 'devise'
 gem 'kaminari', '~> 0.17.0'
 gem 'dotenv-rails'
 
+# elastic-search
+# gem 'elasticsearch-model', git: 'git://github.com/elasticsearch/elasticsearch-rails.git'
+# gem 'elasticsearch-rails', git: 'git://github.com/elasticsearch/elasticsearch-rails.git'
+gem 'elasticsearch-model', git: 'https://github.com/elasticsearch/elasticsearch-rails.git', branch: "5.x"
+gem 'elasticsearch-rails', git: 'https://github.com/elasticsearch/elasticsearch-rails.git', branch: "5.x"
+
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,19 @@
 GIT
+  remote: git://github.com/elasticsearch/elasticsearch-ruby.git
+  revision: 55d09903db62ac70f313ec676113ff0fbcf1aa4f
+  branch: 6.x
+  specs:
+    elasticsearch (6.1.0)
+      elasticsearch-api (= 6.1.0)
+      elasticsearch-transport (= 6.1.0)
+    elasticsearch-api (6.1.0)
+      multi_json
+    elasticsearch-dsl (0.1.5)
+    elasticsearch-transport (6.1.0)
+      faraday
+      multi_json
+
+GIT
   remote: https://github.com/elasticsearch/elasticsearch-rails.git
   revision: 0ba3efc9840ec7cee1720ca69b0b30810c6d30fa
   branch: 6.x
@@ -95,14 +110,6 @@ GEM
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
       railties (>= 3.2, < 6.0)
-    elasticsearch (6.1.0)
-      elasticsearch-api (= 6.1.0)
-      elasticsearch-transport (= 6.1.0)
-    elasticsearch-api (6.1.0)
-      multi_json
-    elasticsearch-transport (6.1.0)
-      faraday
-      multi_json
     erubi (1.7.1)
     execjs (2.7.0)
     faraday (0.15.3)
@@ -242,6 +249,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   dotenv-rails
+  elasticsearch-dsl!
   elasticsearch-model!
   elasticsearch-rails!
   jbuilder (~> 2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/elasticsearch/elasticsearch-rails.git
+  revision: bfdd2243f0de298547b2dc199e9a671cf72ccde6
+  branch: 5.x
+  specs:
+    elasticsearch-model (5.1.0)
+      activesupport (> 3)
+      elasticsearch (~> 5)
+      hashie
+    elasticsearch-rails (5.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -84,11 +95,22 @@ GEM
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
       railties (>= 3.2, < 6.0)
+    elasticsearch (5.0.5)
+      elasticsearch-api (= 5.0.5)
+      elasticsearch-transport (= 5.0.5)
+    elasticsearch-api (5.0.5)
+      multi_json
+    elasticsearch-transport (5.0.5)
+      faraday
+      multi_json
     erubi (1.7.1)
     execjs (2.7.0)
+    faraday (0.15.3)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    hashie (3.6.0)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
@@ -116,6 +138,7 @@ GEM
     minitest (5.11.3)
     msgpack (1.2.4)
     multi_json (1.13.1)
+    multipart-post (2.0.0)
     mysql2 (0.5.2)
     nio4r (2.3.1)
     nokogiri (1.8.4)
@@ -219,6 +242,8 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   dotenv-rails
+  elasticsearch-model!
+  elasticsearch-rails!
   jbuilder (~> 2.5)
   kaminari (~> 0.17.0)
   listen (>= 3.0.5, < 3.2)
@@ -238,4 +263,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: https://github.com/elasticsearch/elasticsearch-rails.git
-  revision: bfdd2243f0de298547b2dc199e9a671cf72ccde6
-  branch: 5.x
+  revision: 0ba3efc9840ec7cee1720ca69b0b30810c6d30fa
+  branch: 6.x
   specs:
-    elasticsearch-model (5.1.0)
+    elasticsearch-model (6.0.0)
       activesupport (> 3)
-      elasticsearch (~> 5)
+      elasticsearch (> 1)
       hashie
-    elasticsearch-rails (5.1.0)
+    elasticsearch-rails (6.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -95,12 +95,12 @@ GEM
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
       railties (>= 3.2, < 6.0)
-    elasticsearch (5.0.5)
-      elasticsearch-api (= 5.0.5)
-      elasticsearch-transport (= 5.0.5)
-    elasticsearch-api (5.0.5)
+    elasticsearch (6.1.0)
+      elasticsearch-api (= 6.1.0)
+      elasticsearch-transport (= 6.1.0)
+    elasticsearch-api (6.1.0)
       multi_json
-    elasticsearch-transport (5.0.5)
+    elasticsearch-transport (6.1.0)
       faraday
       multi_json
     erubi (1.7.1)

--- a/app/controllers/labs_controller.rb
+++ b/app/controllers/labs_controller.rb
@@ -14,8 +14,14 @@ class LabsController < ApplicationController
   # GET /labs
   # GET /labs.json
   def index
+    # 検索用語を取り出す
     @query_string = params[:search]
-    @labs = Lab.page(params[:page]).per(PER_PAGE_LABS_NUM).search(@query_string)
+    # Lab の検索結果(ES より返ってくる object の形式)
+    lab_result = Lab.search(@query_string)
+    # lab_id を取り出す
+    lab_ids = lab_result.map {|obj| obj.id }
+    # lab_id をもとに Lab モデルのオブジェクトを設定
+    @labs = Lab.page(params[:page]).per(PER_PAGE_LABS_NUM).where(id: lab_ids)
   end
 
   # GET /labs/1

--- a/app/models/lab.rb
+++ b/app/models/lab.rb
@@ -1,24 +1,12 @@
 require 'elasticsearch/model'
 
 class Lab < ApplicationRecord
-    # elasticsearch
-    include Elasticsearch::Model
-
     # associations
     has_many :news, dependent: :destroy
     has_many :works, dependent: :destroy
     has_one_attached :image
     has_many :lab_users, dependent: :delete_all
     has_many :users, through: :lab_users
-
-    # 検索ページ用のクラスメソッド
-    # def self.search(search)
-    #     if search
-    #       where(['name LIKE ?', "%#{search}%"])
-    #     else
-    #       all
-    #     end
-    # end
 
     # user が研究室に入っているか
     def is_lab_user?(user)
@@ -29,5 +17,34 @@ class Lab < ApplicationRecord
     def work_names
         names = self.works.map {|work| work.name }
         names.join(',')
+    end
+
+    # elasticsearch
+    include Elasticsearch::Model
+    include Elasticsearch::Model::Callbacks # レコード更新時に自動で反映される
+
+    # マッピング情報
+    settings do
+        mappings dynamic: 'false' do # 動的にマッピングを生成しない
+            indexes :name, analyzer: 'kuromoji', type: 'text'
+            indexes :about_us,  analyzer: 'kuromoji', type: 'text'
+            indexes :purpose, analyzer: 'kuromoji', type: 'text'
+            indexes :message, analyzer: 'kuromoji', type: 'text'
+            indexes :facility, analyzer: 'kuromoji', type: 'text'
+            indexes :works, type: 'nested', include_in_root: true do
+                indexes :name, analyzer: 'kuromoji', type: 'text'
+                indexes :description, analyzer: 'kuromoji', type: 'text'
+            end
+            indexes :image, type: 'nested', include_in_root: true
+        end
+    end
+
+    # インデックスするデータを生成
+    def as_indexed_json(options = {})
+        as_json(
+            only: [:name, :about_us, :purpose, :message, :facility],
+            includes: {
+                works: { only: [:name, :description] },
+            })
     end
 end

--- a/app/models/lab.rb
+++ b/app/models/lab.rb
@@ -1,4 +1,10 @@
+require 'elasticsearch/model'
+
 class Lab < ApplicationRecord
+    # elasticsearch
+    include Elasticsearch::Model
+
+    # associations
     has_many :news, dependent: :destroy
     has_many :works, dependent: :destroy
     has_one_attached :image
@@ -6,13 +12,13 @@ class Lab < ApplicationRecord
     has_many :users, through: :lab_users
 
     # 検索ページ用のクラスメソッド
-    def self.search(search)
-        if search
-          where(['name LIKE ?', "%#{search}%"])
-        else
-          all
-        end
-    end
+    # def self.search(search)
+    #     if search
+    #       where(['name LIKE ?', "%#{search}%"])
+    #     else
+    #       all
+    #     end
+    # end
 
     # user が研究室に入っているか
     def is_lab_user?(user)

--- a/app/views/labs/index.html.erb
+++ b/app/views/labs/index.html.erb
@@ -22,18 +22,21 @@
       <div class="col s12">
         <div class="card horizontal hoverable">
           <div class="card-image">
-          <%# <% if lab.image.attached? 
-            <%= image_tag lab.image, class: "responsive-img z-depth-1 right circle", style: "width: 135px; height: 100%; object-fit: cover;" 
-          <% else
+          <% if lab.image.attached? %>
+            <%= image_tag lab.image, class: "responsive-img z-depth-1 right circle", style: "width: 135px; height: 100%; object-fit: cover;" %>
+          <% else %>
             <!-- no image を設定する予定 -->
           <% end %>
           </div>
           <div class="card-stacked">
             <div class ="card-content">
               <div class="card-title">
-                <span class="card-title"><%= link_to lab.name, "/labs/#{lab.id}
-                " %></span>
+                <span class="card-title"><%= link_to lab.name, lab_path(lab) %></span>
                 <p>
+                  <%= lab.majar %><br/>
+                  <% unless lab.works.empty? %>
+                    研究テーマ: <%= lab.work_names %>
+                  <% end %>
                 </p>
               </div>
             </div>
@@ -60,4 +63,3 @@
   }
   document.getElementById('delete-icon').addEventListener('click', deleteSearchTextEvent);
 </script>
-

--- a/app/views/labs/index.html.erb
+++ b/app/views/labs/index.html.erb
@@ -22,21 +22,18 @@
       <div class="col s12">
         <div class="card horizontal hoverable">
           <div class="card-image">
-          <% if lab.image.attached? %>
-            <%= image_tag lab.image, class: "responsive-img z-depth-1 right circle", style: "width: 135px; height: 100%; object-fit: cover;" %>
-          <% else %>
+          <%# <% if lab.image.attached? 
+            <%= image_tag lab.image, class: "responsive-img z-depth-1 right circle", style: "width: 135px; height: 100%; object-fit: cover;" 
+          <% else
             <!-- no image を設定する予定 -->
           <% end %>
           </div>
           <div class="card-stacked">
             <div class ="card-content">
               <div class="card-title">
-                <span class="card-title"><%= link_to lab.name, lab_path(lab) %></span>
+                <span class="card-title"><%= link_to lab.name, "/labs/#{lab.id}
+                " %></span>
                 <p>
-                  <%= lab.majar %><br/>
-                  <% unless lab.works.empty? %>
-                    研究テーマ: <%= lab.work_names %>
-                  <% end %>
                 </p>
               </div>
             </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require 'elasticsearch/rails/instrumentation'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,0 +1,1 @@
+Elasticsearch::Model.client = Elasticsearch::Client.new({log: true, hosts: { host: 'search'}})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,23 @@ services:
       - "3000:3000"
     depends_on:
       - db
+      - search
+  search:
+    container_name: search
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - esdata1:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
 volumes:
+  esdata1:
+    driver: local
   bundle:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - search
   search:
     container_name: search
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+    build: docker/elasticsearch
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
@@ -28,11 +28,17 @@ services:
         soft: -1
         hard: -1
     volumes:
-      - esdata1:/usr/share/elasticsearch/data
+      - esdata:/usr/share/elasticsearch/data
     ports:
       - 9200:9200
+    expose:
+      - 9300
+  kibana:
+    build: docker/kibana
+    ports:
+        - 5601:5601
 volumes:
-  esdata1:
+  esdata:
     driver: local
   bundle:
     driver: local

--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -1,0 +1,2 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.2.3
+RUN elasticsearch-plugin install analysis-kuromoji

--- a/docker/kibana/Dockerfile
+++ b/docker/kibana/Dockerfile
@@ -1,0 +1,1 @@
+FROM docker.elastic.co/kibana/kibana:6.3.2

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,0 +1,11 @@
+namespace :elasticsearch do
+    desc 'Elasticsearch のindex作成'
+    task :create_index => :environment do
+        Lab.__elasticsearch__.create_index! force: true
+    end
+
+    desc 'Lab を Elasticsearch に登録'
+    task :import_lab => :environment do
+        Lab.import
+    end
+end


### PR DESCRIPTION
やったこと
- ElasticSearch と Kibana のコンテナを docker-compose.yml に追加
- ElasticSearch 関連の gem を追加
- Lab を ElasticSearch に登録するためのタスクを作成

検証方法

```
# ElasticSearch と kibana のイメージをダウンロード
$ docker-compose build

# gem をインストール
$ docker-compose run web bundle install

# インデックスを作成 & Lab を ElasticSearch に登録
$ docker-compose run web bundle exec rake elasticsearch:create_index
$ docker-compose run web bundle exec rake elasticsearch:import_lab

# コンテナを立ち上げる
$ docker-compose up
```
`/labs` のパスにて確認できる。
検索対象のカラムは `lab.name, about_us, purpose, message, facility, works.name, description`
マッチした研究室を結果として表示。