### PR TITLE
has_user修正 #43

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,10 +25,7 @@ class User < ApplicationRecord
 
   # user が研究室に所属しているか
   def has_labs?
-    if self.labs
-        return true
-    end
-    return false
+    return !self.labs.empty?
   end
 
   def get_prime_lab


### PR DESCRIPTION
@Kuratech5 @hiracky16 

ユーザ用ページにてユーザが研究室に所属している場合、所属研究室のリンクを、していない場合は何もリンクを表示しない事確認しました。